### PR TITLE
chore: update MADs precompile contract

### DIFF
--- a/src/MultiAssetDelegation.sol
+++ b/src/MultiAssetDelegation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.8.20;
+pragma solidity >=0.8.3;
 
 /// @dev The MultiAssetDelegation contract's address.
 address constant MULTI_ASSET_DELEGATION = 0x0000000000000000000000000000000000000822;
@@ -14,35 +14,45 @@ MultiAssetDelegation constant MULTI_ASSET_DELEGATION_CONTRACT = MultiAssetDelega
 interface MultiAssetDelegation {
     /// @dev Join as an operator with a bond amount.
     /// @param bondAmount The amount to bond as an operator.
+    /// @custom:selector de883d74
     function joinOperators(uint256 bondAmount) external;
 
     /// @dev Schedule to leave as an operator.
+    /// @custom:selector ce3edd76
     function scheduleLeaveOperators() external;
 
     /// @dev Cancel the scheduled leave as an operator.
+    /// @custom:selector 9b1300c1
     function cancelLeaveOperators() external;
 
     /// @dev Execute the leave as an operator.
+    /// @custom:selector 0de1fc17
     function executeLeaveOperators() external;
 
     /// @dev Bond more as an operator.
     /// @param additionalBond The additional amount to bond.
+    /// @custom:selector eede281b
     function operatorBondMore(uint256 additionalBond) external;
 
     /// @dev Schedule to unstake as an operator.
     /// @param unstakeAmount The amount to unstake.
+    /// @custom:selector 44aff252
     function scheduleOperatorUnstake(uint256 unstakeAmount) external;
 
     /// @dev Execute the unstake as an operator.
+    /// @custom:selector b0dfce06
     function executeOperatorUnstake() external;
 
     /// @dev Cancel the scheduled unstake as an operator.
+    /// @custom:selector ac359f2b
     function cancelOperatorUnstake() external;
 
     /// @dev Go offline as an operator.
+    /// @custom:selector a6485ccd
     function goOffline() external;
 
     /// @dev Go online as an operator.
+    /// @custom:selector 6e5b676b
     function goOnline() external;
 
     /// @dev Deposit an amount of an asset.
@@ -50,21 +60,25 @@ interface MultiAssetDelegation {
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to deposit.
     /// @param lockMultiplier The lock multiplier.
+    /// @custom:selector b3c11395
     function deposit(uint256 assetId, address tokenAddress, uint256 amount, uint8 lockMultiplier) external;
 
     /// @dev Schedule a withdrawal of an amount of an asset.
     /// @param assetId The ID of the asset (0 for ERC20).
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to withdraw.
+    /// @custom:selector a125b146
     function scheduleWithdraw(uint256 assetId, address tokenAddress, uint256 amount) external;
 
     /// @dev Execute the scheduled withdrawal.
+    /// @custom:selector f8fd9795
     function executeWithdraw() external;
 
     /// @dev Cancel the scheduled withdrawal.
     /// @param assetId The ID of the asset (0 for ERC20).
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to cancel withdrawal.
+    /// @custom:selector 098d2a20
     function cancelWithdraw(uint256 assetId, address tokenAddress, uint256 amount) external;
 
     /// @dev Delegate an amount of an asset to an operator.
@@ -73,6 +87,7 @@ interface MultiAssetDelegation {
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to delegate.
     /// @param blueprintSelection The blueprint selection.
+    /// @custom:selector a12de0ba
     function delegate(
         bytes32 operator,
         uint256 assetId,
@@ -86,10 +101,12 @@ interface MultiAssetDelegation {
     /// @param assetId The ID of the asset (0 for ERC20).
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to unstake.
+    /// @custom:selector 5bea61c6
     function scheduleDelegatorUnstake(bytes32 operator, uint256 assetId, address tokenAddress, uint256 amount)
         external;
 
     /// @dev Execute the scheduled unstake as a delegator.
+    /// @custom:selector 007910d0
     function executeDelegatorUnstake() external;
 
     /// @dev Cancel the scheduled unstake as a delegator.
@@ -97,5 +114,22 @@ interface MultiAssetDelegation {
     /// @param assetId The ID of the asset (0 for ERC20).
     /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
     /// @param amount The amount to cancel unstake.
+    /// @custom:selector 504aff13
     function cancelDelegatorUnstake(bytes32 operator, uint256 assetId, address tokenAddress, uint256 amount) external;
+
+    /// @dev Get the total balance of the delegator (including the delegated balance).
+    /// @param who The address of the account.
+    /// @param assetId The ID of the asset (0 for ERC20).
+    /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
+    /// @return The total balance of the delegator.
+    /// @custom:selector 467f4cb9
+    function balanceOf(address who, uint256 assetId, address tokenAddress) external view returns (uint256);
+
+    /// @dev Get the delegated balance of the delegator.
+    /// @param who The address of the delegator.
+    /// @param assetId The ID of the asset (0 for ERC20).
+    /// @param tokenAddress The address of the ERC20 token (if assetId is 0).
+    /// @return The delegated balance of the delegator.
+    /// @custom:selector aabd20df
+    function delegatedBalanceOf(address who, uint256 assetId, address tokenAddress) external view returns (uint256);
 }

--- a/src/TangleLiquidRestakingVault.sol
+++ b/src/TangleLiquidRestakingVault.sol
@@ -633,7 +633,7 @@ contract TangleLiquidRestakingVault is ERC4626, Owned, TangleMultiAssetDelegatio
     /// @dev Returns total base assets, excluding reward tokens
     /// @return Total value in terms of asset tokens
     function totalAssets() public view override returns (uint256) {
-        return asset.balanceOf(address(this));
+        return _balanceOf(address(this));
     }
 
     /// @notice Get reward data for a token

--- a/src/TangleMultiAssetDelegationWrapper.sol
+++ b/src/TangleMultiAssetDelegationWrapper.sol
@@ -45,6 +45,13 @@ abstract contract TangleMultiAssetDelegationWrapper {
 
     /* ============ Internal Functions ============ */
 
+    /// @notice Get the current balance of the delegator
+    /// @param delegator The delegator to get the balance for
+    /// @return The balance of the delegator
+    function _balanceOf(address delegator) internal view returns (uint256) {
+        return mads.balanceOf(delegator, 0, address(token));
+    }
+
     /// @notice Deposit assets into the delegation system
     /// @param amount Amount of assets to deposit
     function _deposit(uint256 amount) internal {

--- a/test/TangleLiquidRestakingVault.t.sol
+++ b/test/TangleLiquidRestakingVault.t.sol
@@ -43,7 +43,7 @@ contract TangleLiquidRestakingVaultTest is Test {
         baseToken = new MockERC20("Base Token", "BASE", 18);
         rewardToken1 = new MockERC20("Reward Token 1", "RWD1", 18);
         rewardToken2 = new MockERC20("Reward Token 2", "RWD2", 18);
-        mockMADS = new MockMultiAssetDelegation();
+        mockMADS = new MockMultiAssetDelegation(baseToken);
         blueprintSelection = new uint64[](1);
         blueprintSelection[0] = 1;
 

--- a/test/mock/MockMultiAssetDelegation.sol
+++ b/test/mock/MockMultiAssetDelegation.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import {ERC20} from "dependencies/solmate-6.8.0/src/tokens/ERC20.sol";
 import {MultiAssetDelegation} from "../../src/MultiAssetDelegation.sol";
 
 contract MockMultiAssetDelegation is MultiAssetDelegation {
@@ -17,6 +18,12 @@ contract MockMultiAssetDelegation is MultiAssetDelegation {
     mapping(address => ScheduleState) public scheduledUnstakes;
     mapping(address => ScheduleState) public scheduledWithdraws;
     mapping(address => uint256) public delegatedAmounts;
+
+    ERC20 public immutable token;
+
+    constructor(ERC20 _token) {
+        token = _token;
+    }
 
     // Events
     event Delegated(
@@ -56,7 +63,6 @@ contract MockMultiAssetDelegation is MultiAssetDelegation {
 
     // Deposit function - just track delegated amount
     function deposit(uint256, address, uint256 amount, uint8) external {
-        delegatedAmounts[msg.sender] += amount;
         emit Delegated(address(0), msg.sender, amount, bytes32(0), new uint64[](0));
     }
 
@@ -153,5 +159,13 @@ contract MockMultiAssetDelegation is MultiAssetDelegation {
         // Return the scheduled amount for the caller (vault), not the end user
         ScheduleState storage state = scheduledWithdraws[tokenAddress];
         return (state.amount, state.timestamp);
+    }
+
+    function balanceOf(address who, uint256, address) external view returns (uint256) {
+        return token.balanceOf(who);
+    }
+
+    function delegatedBalanceOf(address who, uint256, address) external view returns (uint256) {
+        return delegatedAmounts[who];
     }
 }


### PR DESCRIPTION
This pull request includes several changes focusing on the `MultiAssetDelegation` interface and related contracts. The main updates involve adding custom selectors to functions, modifying the balance retrieval logic, and updating the mock contract for testing purposes.

### Interface Updates:
* Added `@custom:selector` annotations to all functions in the `MultiAssetDelegation` interface to specify their selectors. [[1]](diffhunk://#diff-3b19c8a1f2bba64b8aaab28a9315cf73b5a162c03de4e6877c2421ed685c77f0R17-R81) [[2]](diffhunk://#diff-3b19c8a1f2bba64b8aaab28a9315cf73b5a162c03de4e6877c2421ed685c77f0R90) [[3]](diffhunk://#diff-3b19c8a1f2bba64b8aaab28a9315cf73b5a162c03de4e6877c2421ed685c77f0R104-R134)

### Balance Retrieval:
* Introduced a new internal function `_balanceOf` in `TangleMultiAssetDelegationWrapper` to get the current balance of a delegator.
* Updated the `totalAssets` function in `TangleLiquidRestakingVault` to use `_balanceOf` instead of `asset.balanceOf`.

### Mock Contract Updates:
* Modified `MockMultiAssetDelegation` to include a constructor that accepts an `ERC20` token and added functions to retrieve balances. [[1]](diffhunk://#diff-c82ca5501754952dae77c03430a2796b9bc9742642f5a3ee6866063c637a3f88R4) [[2]](diffhunk://#diff-c82ca5501754952dae77c03430a2796b9bc9742642f5a3ee6866063c637a3f88R22-R27) [[3]](diffhunk://#diff-c82ca5501754952dae77c03430a2796b9bc9742642f5a3ee6866063c637a3f88R163-R170)
* Updated the `MockMultiAssetDelegation` contract to track delegated amounts and return balances accordingly.

### Testing Updates:
* Updated the `TangleLiquidRestakingVaultTest` to initialize `MockMultiAssetDelegation` with a base token.

Closes #2 